### PR TITLE
[wiki] Fix "compile errors" in Containers.md

### DIFF
--- a/docs/Containers.md
+++ b/docs/Containers.md
@@ -29,9 +29,9 @@ For example:
 using StrongInject;
 
 [Register(typeof(A))]
-public class MyContainer : IContainer<A>() {}
+public partial class MyContainer : IContainer<A> {}
 
-public class A : IDisposable { public void Dispose(){} }
+public class A : IDisposable { public void Dispose() { } }
 
 var myContainer = new MyContainer();
 myContainer.Run(a => Console.WriteLine($"We've resolved an instance of A: {a.ToString()}!!"));
@@ -43,13 +43,13 @@ You can also return a result from `Run` and use that:
 using StrongInject;
 
 [Register(typeof(A))]
-public class MyContainer : IContainer<A>() {}
+public partial class MyContainer : IContainer<A> { }
 
-public class A : IDisposable { public void Dispose(){} }
+public class A : IDisposable { public void Dispose() { } }
 
 var myContainer = new MyContainer();
 var aString = myContainer.Run(a => a.ToString());
-Console.WriteLine($"We've resolved an instance of A: {aString()}!!");
+Console.WriteLine($"We've resolved an instance of A: {aString}!!");
 ```
 
 Either way, you must make sure that the resolved type, and any of its dependencies, do not escape the scope of the delegate, or you may end up using them after they are disposed.


### PR DESCRIPTION
I suggest trying all code examples before publishing them to the wiki. I fixed these kinds of errors in the Containers.md file.

Also, I don't know if the code snippets are meant to be runnable, but:
1. If you are using "top level programs" feature of C# to run this, that won't work since code should be first, defined classes afterwards, so the code in the wiki does not compile.
2. Maybe it would be better to have a console application example, but there we would need more code, example:
```csharp
using System;
using StrongInject;

namespace Examples
{
    [Register(typeof(A))]
    public partial class MyContainer : IContainer<A> { }

    public class A : IDisposable { public void Dispose() { } }

    static class Program
    {
        static void Main()
        {
            var myContainer = new MyContainer();
            myContainer.Run(a => Console.WriteLine($"We've resolved an instance of A: {a.ToString()}!!"));
        }
    }
}
```