### PR TITLE
Prevent accidentally calling wrong overload of RunAsync when using a Task

### DIFF
--- a/StrongInject.Extensions.DependencyInjection/StrongInject.Extensions.DependencyInjection.csproj
+++ b/StrongInject.Extensions.DependencyInjection/StrongInject.Extensions.DependencyInjection.csproj
@@ -10,7 +10,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<VersionPrefix>0.0.2</VersionPrefix>
+		<VersionPrefix>0.0.3</VersionPrefix>
 		<PackageId>StrongInject.Extensions.DependencyInjection</PackageId>
 		<Authors>StrongInject</Authors>
 		<Product>StrongInject</Product>

--- a/StrongInject/ContainerExtensions.cs
+++ b/StrongInject/ContainerExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using StrongInject.Internal;
+using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace StrongInject
@@ -39,10 +41,36 @@ namespace StrongInject
             return container.RunAsync(static (t, func) => func(t), func);
         }
 
-        public static ValueTask<TResult> RunAsync<T, TResult>(this IAsyncContainer<T> container, Func<T, TResult> func)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        /// <param name="container"></param>
+        /// <param name="func"></param>
+        /// <param name="_">Ignore this parameter. Used to prefer overload <see cref="RunAsync{T, TResult}(IAsyncContainer{T}, Func{T, ValueTask{TResult}})"/> to this overload.</param>
+        /// <returns></returns>
+        public static ValueTask<TResult> RunAsync<T, TResult>(this IAsyncContainer<T> container, Func<T, Task<TResult>> func, DummyParameter? _ = null)
         {
             return container.RunAsync(static (t, func) => new ValueTask<TResult>(func(t)), func);
         }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        /// <param name="container"></param>
+        /// <param name="func"></param>
+        /// <param name="_">Ignore this parameter. Used to prefer overload <see cref="RunAsync{T, TResult}(IAsyncContainer{T}, Func{T, Task{TResult}}, DummyParameter?)"/> to this overload.</param>
+        /// <returns></returns>
+        public static ValueTask<TResult> RunAsync<T, TResult>(this IAsyncContainer<T> container, Func<T, TResult> func, DummyParameter? _ = null)
+        {
+            return container.RunAsync(static (t, func) => new ValueTask<TResult>(func(t)), func);
+        }
+
+        [Obsolete, EditorBrowsable(EditorBrowsableState.Never)]
+        public static ValueTask<TResult> RunAsync<T, TResult>(IAsyncContainer<T> container, Func<T, TResult> func) => container.RunAsync(func);
 
         public static ValueTask RunAsync<T>(this IAsyncContainer<T> container, Func<T, ValueTask> action)
         {
@@ -53,7 +81,32 @@ namespace StrongInject
             }, action).AsValueTask();
         }
 
-        public static ValueTask RunAsync<T>(this IAsyncContainer<T> container, Action<T> action)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="container"></param>
+        /// <param name="action"></param>
+        /// <param name="_">Ignore this parameter. Used to prefer overload <see cref="RunAsync{T}(IAsyncContainer{T}, Func{T, ValueTask})"/> to this overload.</param>
+        /// <returns></returns>
+        public static ValueTask RunAsync<T>(this IAsyncContainer<T> container, Func<T, Task> action, DummyParameter? _ = null)
+        {
+            return container.RunAsync(static async (t, action) =>
+            {
+                await action(t);
+                return default(object?);
+            }, action).AsValueTask();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="container"></param>
+        /// <param name="action"></param>
+        /// <param name="_">Ignore this parameter. Used to prefer overload <see cref="RunAsync{T}(IAsyncContainer{T}, Func{T, Task}, DummyParameter?)"/> to this overload.</param>
+        /// <returns></returns>
+        public static ValueTask RunAsync<T>(this IAsyncContainer<T> container, Action<T> action, DummyParameter? _ = null)
         {
             return container.RunAsync(static (t, action) =>
             {
@@ -61,6 +114,9 @@ namespace StrongInject
                 return new ValueTask<object?>(default(object));
             }, action).AsValueTask();
         }
+
+        [Obsolete, EditorBrowsable(EditorBrowsableState.Never)]
+        public static ValueTask RunAsync<T>(IAsyncContainer<T> container, Action<T> action) => container.RunAsync(action);
 
         public static ValueTask<AsyncOwned<T>> ResolveAsync<T>(this IAsyncContainer<T> container) => container.ResolveAsync();
     }

--- a/StrongInject/DummyParameter.cs
+++ b/StrongInject/DummyParameter.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel;
+
+namespace StrongInject.Internal
+{
+    /// <summary>
+    /// A class with no possible value other than null. Used to mark an optional parameter which should never be set.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class DummyParameter
+    {
+        private DummyParameter() { }
+    }
+}
+

--- a/StrongInject/StrongInject.csproj
+++ b/StrongInject/StrongInject.csproj
@@ -10,7 +10,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<VersionPrefix>1.0.1</VersionPrefix>
+		<VersionPrefix>1.0.2</VersionPrefix>
 		<PackageId>StrongInject</PackageId>
 		<Authors>StrongInject</Authors>
 		<Product>StrongInject</Product>


### PR DESCRIPTION
We currently have 2 extension methods:

```csharp
public static ValueTask<TResult> RunAsync<T, TResult>(this IAsyncContainer<T> container, Func<T, ValueTask<TResult>> func);

public static ValueTask<TResult> RunAsync<T, TResult>(this IAsyncContainer<T> container, Func<T, TResult> func);
```

The problem with this is if I do:

```csharp
container.RunAsync(x => Task.Run(x => 42))
```

It will match the overload accepting `Func<T, TResult>` and thus run without waiting for the result.

So I tried adding an overload accepting Task:

```csharp
public static ValueTask<TResult> RunAsync<T, TResult>(this IAsyncContainer<T> container, Func<T, Task<TResult>> func);
```

The problem is now when I do this:

```csharp
container.RunAsync(x => await Task.Run(x => 42))
```

We get ambiguous overload resolution.

In order to remain binary and source backwards compatible, but call the correct overloads, we can do this:

```csharp
        public static ValueTask<TResult> RunAsync<T, TResult>(this IAsyncContainer<T> container, Func<T, ValueTask<TResult>> func)
        {
            return container.RunAsync(static (t, func) => func(t), func);
        }

        /// <summary>
        /// 
        /// </summary>
        /// <typeparam name="T"></typeparam>
        /// <typeparam name="TResult"></typeparam>
        /// <param name="container"></param>
        /// <param name="func"></param>
        /// <param name="_">Ignore this parameter. Used to prefer overload <see cref="RunAsync{T, TResult}(IAsyncContainer{T}, Func{T, ValueTask{TResult}})"/> to this overload.</param>
        /// <returns></returns>
        public static ValueTask<TResult> RunAsync<T, TResult>(this IAsyncContainer<T> container, Func<T, Task<TResult>> func, DummyParameter? _ = null)
        {
            return container.RunAsync(static (t, func) => new ValueTask<TResult>(func(t)), func);
        }

        /// <summary>
        /// 
        /// </summary>
        /// <typeparam name="T"></typeparam>
        /// <typeparam name="TResult"></typeparam>
        /// <param name="container"></param>
        /// <param name="func"></param>
        /// <param name="_">Ignore this parameter. Used to prefer overload <see cref="RunAsync{T, TResult}(IAsyncContainer{T}, Func{T, Task{TResult}}, DummyParameter?)"/> to this overload.</param>
        /// <returns></returns>
        public static ValueTask<TResult> RunAsync<T, TResult>(this IAsyncContainer<T> container, Func<T, TResult> func, DummyParameter? _ = null)
        {
            return container.RunAsync(static (t, func) => new ValueTask<TResult>(func(t)), func);
        }

        [Obsolete, EditorBrowsable(EditorBrowsableState.Never)]
        public static ValueTask<TResult> RunAsync<T, TResult>(IAsyncContainer<T> container, Func<T, TResult> func) => container.RunAsync(func);
```

This has the desired overload resolution behaviour, but is ugly.

OTOH, the user is only exposed to this ugliness when looking at sig help. When reading the code, it reads fine, and works as expected.