### PR TITLE
Allow registration of internal types

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -3,11 +3,6 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
-    <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
-    <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
-    <add key="roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
-    <add key="roslyn-analyzers" value="https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json" />
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/StrongInject.sln
+++ b/StrongInject.sln
@@ -13,6 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
+		NuGet.config = NuGet.config
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Utilities", "Utilities", "{EB46F000-80AB-4A94-A684-080CE86F9113}"

--- a/StrongInject/Generator/ContainerGenerator.cs
+++ b/StrongInject/Generator/ContainerGenerator.cs
@@ -65,7 +65,7 @@ namespace StrongInject.Generator
 
             // Ideally we would use the location of the interface in the base list, however getting that location is complex and not critical for now.
             // See http://sourceroslyn.io/#Microsoft.CodeAnalysis.CSharp/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs,333
-            _containerDeclarationLocation = ((ClassDeclarationSyntax)_container.DeclaringSyntaxReferences[0].GetSyntax()).Identifier.GetLocation();
+            _containerDeclarationLocation = ((TypeDeclarationSyntax)_container.DeclaringSyntaxReferences[0].GetSyntax()).Identifier.GetLocation();
         }
 
         private string GenerateContainerImplementations()

--- a/StrongInject/Generator/Operation.cs
+++ b/StrongInject/Generator/Operation.cs
@@ -26,8 +26,7 @@ namespace StrongInject.Generator
         {
             if (operation.Statement is not AwaitStatement { VariableName: not null })
                 return false;
-            var originalOperation = operation.Dependencies[0];
-            return originalOperation is InitializationStatement ? originalOperation.Dependencies[0].CanDisposeLocally : originalOperation.CanDisposeLocally;
+            return operation.Dependencies[0].CanDisposeLocally;
         }
     }
 }

--- a/StrongInject/Generator/SourceGenerator.cs
+++ b/StrongInject/Generator/SourceGenerator.cs
@@ -54,6 +54,13 @@ namespace StrongInject.Generator
 
                 foreach (var module in modules)
                 {
+                    if (!module.type.IsInternal() && !module.type.IsPublic())
+                    {
+                        reportDiagnostic(ModuleNotPublicOrInternal(
+                            module.type,
+                            ((TypeDeclarationSyntax)module.type.DeclaringSyntaxReferences[0].GetSyntax()).Identifier.GetLocation()));
+                    }
+
                     cancellationToken.ThrowIfCancellationRequested();
                     if (module.isContainer)
                     {
@@ -96,6 +103,20 @@ namespace StrongInject.Generator
 
         public void Initialize(GeneratorInitializationContext context)
         {
+        }
+
+        private static Diagnostic ModuleNotPublicOrInternal(ITypeSymbol module, Location location)
+        {
+            return Diagnostic.Create(
+                new DiagnosticDescriptor(
+                    "SI0401",
+                    "Module must be public or internal.",
+                    "Module '{0}' must be public or internal.",
+                    "StrongInject",
+                    DiagnosticSeverity.Error,
+                    isEnabledByDefault: true),
+                location,
+                module);
         }
     }
 }


### PR DESCRIPTION
A type which is not completely public, may only be registered with a module which has at most internal visibility without warning.

A module which has at most internal visibility can only be registered with a module which has at most internal visibility without warning.

Modules must be public or internal, not protected, private, protected internal, private protected, or some other combination.

Types must have a minimum of internal visibility.