### PR TITLE
Fix windows build

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -84,12 +84,8 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '5.0.x'
-    - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.0.2
-    - name: Setup NuGet
-      uses: nuget/setup-nuget@v1
     - name: Install dependencies
-      run: nuget restore
+      run: dotnet restore
     - name: Build
       run: dotnet build -c Debug --no-restore
     - name: Build WPF

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -90,7 +90,9 @@ jobs:
       uses: nuget/setup-nuget@v1
     - name: Install dependencies
       run: nuget restore
-    - name: Build All
-      run: msbuild .\StrongInject.sln /verbosity:minimal /t:Rebuild /p:Configuration=Wpf
+    - name: Build
+      run: dotnet build -c Debug --no-restore
+    - name: Build WPF
+      run: dotnet build -c Wpf --no-restore
     - name: Test
-      run: dotnet test -c Debug --verbosity normal
+      run: dotnet test -c Debug --no-restore --verbosity normal

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -89,6 +89,6 @@ jobs:
     - name: Build
       run: dotnet build -c Debug --no-restore
     - name: Build WPF
-      run: dotnet build -c Wpf --no-restore
+      run: dotnet build -c Wpf
     - name: Test
       run: dotnet test -c Debug --no-restore --verbosity normal

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -83,7 +83,8 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.x'
+        dotnet-version: '6.0.x'
+        include-prerelease: true
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v1.0.2
     - name: Setup NuGet

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -89,6 +89,8 @@ jobs:
       uses: microsoft/setup-msbuild@v1.0.2
     - name: Setup NuGet
       uses: nuget/setup-nuget@v1
+      with:
+        nuget-version: preview
     - name: Install dependencies
       run: nuget restore
     - name: Build All

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -83,17 +83,14 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '6.0.x'
-        include-prerelease: true
+        dotnet-version: '5.0.x'
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v1.0.2
     - name: Setup NuGet
       uses: nuget/setup-nuget@v1
-      with:
-        nuget-version: preview
     - name: Install dependencies
       run: nuget restore
     - name: Build All
-      run: msbuild .\StrongInject.sln /verbosity:minimal /t:Rebuild /p:Configuration=All
+      run: msbuild .\StrongInject.sln /verbosity:minimal /t:Rebuild /p:Configuration=Wpf
     - name: Test
       run: dotnet test -c Debug --verbosity normal

--- a/StrongInject.sln
+++ b/StrongInject.sln
@@ -633,7 +633,6 @@ Global
 		{1684B68F-699F-457F-8891-99DC2569420B}.All|x86.ActiveCfg = Debug|Any CPU
 		{1684B68F-699F-457F-8891-99DC2569420B}.All|x86.Build.0 = Debug|Any CPU
 		{1684B68F-699F-457F-8891-99DC2569420B}.AndroidApp|Any CPU.ActiveCfg = Debug|Any CPU
-		{1684B68F-699F-457F-8891-99DC2569420B}.AndroidApp|Any CPU.Build.0 = Debug|Any CPU
 		{1684B68F-699F-457F-8891-99DC2569420B}.AndroidApp|iPhone.ActiveCfg = Debug|Any CPU
 		{1684B68F-699F-457F-8891-99DC2569420B}.AndroidApp|iPhone.Build.0 = Debug|Any CPU
 		{1684B68F-699F-457F-8891-99DC2569420B}.AndroidApp|iPhoneSimulator.ActiveCfg = Debug|Any CPU
@@ -662,8 +661,6 @@ Global
 		{1684B68F-699F-457F-8891-99DC2569420B}.Release|x64.Build.0 = Release|Any CPU
 		{1684B68F-699F-457F-8891-99DC2569420B}.Release|x86.ActiveCfg = Release|Any CPU
 		{1684B68F-699F-457F-8891-99DC2569420B}.Release|x86.Build.0 = Release|Any CPU
-		{1684B68F-699F-457F-8891-99DC2569420B}.Wpf|Any CPU.ActiveCfg = Debug|Any CPU
-		{1684B68F-699F-457F-8891-99DC2569420B}.Wpf|Any CPU.Build.0 = Debug|Any CPU
 		{1684B68F-699F-457F-8891-99DC2569420B}.Wpf|iPhone.ActiveCfg = Debug|Any CPU
 		{1684B68F-699F-457F-8891-99DC2569420B}.Wpf|iPhone.Build.0 = Debug|Any CPU
 		{1684B68F-699F-457F-8891-99DC2569420B}.Wpf|iPhoneSimulator.ActiveCfg = Debug|Any CPU
@@ -672,6 +669,7 @@ Global
 		{1684B68F-699F-457F-8891-99DC2569420B}.Wpf|x64.Build.0 = Debug|Any CPU
 		{1684B68F-699F-457F-8891-99DC2569420B}.Wpf|x86.ActiveCfg = Debug|Any CPU
 		{1684B68F-699F-457F-8891-99DC2569420B}.Wpf|x86.Build.0 = Debug|Any CPU
+		{1684B68F-699F-457F-8891-99DC2569420B}.Wpf|Any CPU.ActiveCfg = Wpf|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Use dotnet which is much more reliable than msbuild as it doesnt depend on the image configuration.
At the moment this means we don't test xamarin. I've opened https://github.com/YairHalberstadt/stronginject/issues/147 to fix that.