### PR TITLE
Clarify 'delegate parameters' in contexts where it could be read as 'delegate-typed parameters'

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,7 +543,7 @@ You can't specify the scope of a decorator, as its scope is the same as that of 
 
 The decorator constructor must have exactly one parameter of the decorated type, but can have any other parameters as well so long as they are not of the decorated type.
 
-Instances provided by [delegate parameters](#delegate-support) are never decorated.
+Instances passed to [parameters of delegates](#delegate-support) are never decorated.
 
 You can also define decorator factory methods, and even generic decorator factory methods via the `[DecoratorFactoryAttribute]`:
 

--- a/Samples/Wpf/README.md
+++ b/Samples/Wpf/README.md
@@ -14,7 +14,7 @@ The WPF app is not built by the Debug/Release configurations as it can only be b
 
 WPF classically expects user controls and view models to have a parameterless constructor, and then use a service locator instead of DI to access needed services. This is rightly [considered an anti pattern](https://blog.ploeh.dk/2010/02/03/ServiceLocatorisanAnti-Pattern/).
 
-Instead we instantiate a tree of view models using StrongInject. Each ViewModel accepts any child ViewModels directly in it's constructor, or via a `Func`. Every `ViewModel` exposes the child ViewModels as properties.
+Instead we instantiate a tree of view models using StrongInject. Each ViewModel accepts any child ViewModels directly in its constructor, or via a `Func`. Every `ViewModel` exposes the child ViewModels as properties.
 
 We resolve the `MainWindow` directly, and the `MainWindow` sets the `MainWindowViewModel` as its `DataContext` in its constructor.
 

--- a/StrongInject/DecoratorFactoryAttribute.cs
+++ b/StrongInject/DecoratorFactoryAttribute.cs
@@ -3,7 +3,7 @@
 namespace StrongInject
 {
     /// <summary>
-    /// Use this to mark a method as a decorater for it's return type.
+    /// Use this to mark a method as a decorator for its return type.
     /// Exactly one of the parameters must be the same type as the return type.
     /// When resolving an instance of the return type, once the type has been resolved as normal it will be passed as a parameter to the method.
     /// You can mark both normal methods and generic methods with this attribute.

--- a/StrongInject/IFactory.cs
+++ b/StrongInject/IFactory.cs
@@ -5,7 +5,7 @@ namespace StrongInject
     /// <summary>
     /// A type implementing this interface can be registered as a factory for <typeparamref name="T"/>.
     /// It can be registered either via the <see cref="RegisterFactoryAttribute"/>,
-    /// or by marking a field/property with the <see cref="InstanceAttribute"/> and configuring it's <see cref="InstanceAttribute.Options"/>.
+    /// or by marking a field/property with the <see cref="InstanceAttribute"/> and configuring its <see cref="InstanceAttribute.Options"/>.
     /// 
     /// In general it's easier to use factory methods instead (methods marked with the <see cref="FactoryAttribute"/>.
     /// Only use this if you either need control over the lifetime of the factory,
@@ -28,7 +28,7 @@ namespace StrongInject
     /// <summary>
     /// A type implementing this interface can be registered as an async factory for <typeparamref name="T"/>.
     /// It can be registered either via the <see cref="RegisterFactoryAttribute"/>,
-    /// or by marking a field/property with the <see cref="InstanceAttribute"/> and configuring it's <see cref="InstanceAttribute.Options"/>.
+    /// or by marking a field/property with the <see cref="InstanceAttribute"/> and configuring its <see cref="InstanceAttribute.Options"/>.
     /// 
     /// In general it's easier to use factory methods instead (methods marked with the <see cref="FactoryAttribute"/>.
     /// Only use this if you either need control over the lifetime of the factory,

--- a/docs/Registration/DecoratorTypeRegistration.md
+++ b/docs/Registration/DecoratorTypeRegistration.md
@@ -12,7 +12,7 @@
 
 # Decorator Type Registration
 
-You can register a type as a decorator for it's base classes/interfaces. StrongInject will look for a suitable constructor to use to instantiate it.
+You can register a type as a decorator for its base classes/interfaces. StrongInject will look for a suitable constructor to use to instantiate it.
 
 To register a type as a decorator, add the `[RegisterDecorator]` attribute to a container or module.
 

--- a/docs/Registration/Decorators.md
+++ b/docs/Registration/Decorators.md
@@ -12,9 +12,9 @@
 
 # Decorators
 
-A Decorator is different to other registrations, in that it does not provide an instance of a type, but rather wraps/modifies an *underlying* instance of a type, which is redolved in the normal manner.
+A Decorator is different to other registrations, in that it does not provide an instance of a type, but rather wraps/modifies an *underlying* instance of a type, which is resolved in the normal manner.
 
-If multiple decorators are registered for a type, all of them will be applied, by wrapping one decorator in another, onion style. The order in which decorators wrap each other is deterministic but an implmentation detail - you should not rely on this order.
+If multiple decorators are registered for a type, all of them will be applied, by wrapping one decorator in another, onion style. The order in which decorators wrap each other is deterministic but an implementation detail - you should not rely on this order.
 
 Decorators are not applied to delegate parameters, or to `[Instance]` fields and properties with Options.DoNotDecorate applied. They are applied to everything else.
 

--- a/docs/Registration/Decorators.md
+++ b/docs/Registration/Decorators.md
@@ -16,7 +16,7 @@ A Decorator is different to other registrations, in that it does not provide an 
 
 If multiple decorators are registered for a type, all of them will be applied, by wrapping one decorator in another, onion style. The order in which decorators wrap each other is deterministic but an implementation detail - you should not rely on this order.
 
-Decorators are not applied to delegate parameters, or to `[Instance]` fields and properties with Options.DoNotDecorate applied. They are applied to everything else.
+Decorators are not applied to parameters of delegates, or to `[Instance]` fields and properties with Options.DoNotDecorate applied. They are applied to everything else.
 
 ## Decorator Registration
 

--- a/docs/Registration/InstanceRegistration.md
+++ b/docs/Registration/InstanceRegistration.md
@@ -38,7 +38,7 @@ In order for an instance field or property to be exported by a module it must be
 
 The registration can be modified using the `options` parameter. See the [documentation](https://github.com/YairHalberstadt/stronginject/wiki/Registration#options) for more details.
 
-This allows you to register the instance as more than just the type of the the field/property. In particular it is possible to register the instance as it's:
+This allows you to register the instance as more than just the type of the the field/property. In particular it is possible to register the instance as its:
 
 1. Base classes
 2. Interfaces


### PR DESCRIPTION
First commit fixes typos. Also, 'its' doesn't look like a word to me now. :D

Second commit closes #190.